### PR TITLE
Added custom.css & Collision of "description" variable in Blueprint and Twig

### DIFF
--- a/blueprints/modular/links.yaml
+++ b/blueprints/modular/links.yaml
@@ -64,7 +64,7 @@ form:
                                             label: URL
                                             help: >
                                                 External or internal link. Leave blank if your title should not be clickable.
-                                        .sublabel:
+                                        .description:
                                             type: text
                                             label: (Optional) Description
                                             help: >

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -13,6 +13,7 @@
 	{% block stylesheets %}
 		{% do assets.addCss('theme://fonts/opensans/opensans.css?fp=4702', {group: 'init'}) %}
 		{% do assets.addCss('theme://dist/css/main.css?fp=4702', {group: 'init'}) %}
+		{% do assets.addCss('theme://css/custom.css', {group: 'init'}) %}
 		{# head: blocking scripts #}		
 		{{ assets.css('init')|raw }}
 		{# head: with loading parameter #}


### PR DESCRIPTION
Added the ability to insert custom styles via custom.css.

Collision of variable name with Twig template. Unified to original "description", it is more specific than "sublabel".

Resolved in connection with PR #21.