### PR TITLE
Collision of "description" variable in Blueprint and Twig

### DIFF
--- a/blueprints/modular/links.yaml
+++ b/blueprints/modular/links.yaml
@@ -64,7 +64,7 @@ form:
                                             label: URL
                                             help: >
                                                 External or internal link. Leave blank if your title should not be clickable.
-                                        .sublabel:
+                                        .description:
                                             type: text
                                             label: (Optional) Description
                                             help: >


### PR DESCRIPTION
Collision of variable name with Twig template. Unified to original "description", it is more specific than "sublabel".