### PR TITLE
Custom sitename separator in page title

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -56,6 +56,13 @@ form:
                 1: PLUGIN_ADMIN.ENABLED
             validate:
                 type: bool
+        sitetitleseparator:
+            type: text
+            size: small
+            label: Sitename separator in page title
+            description: >
+                <small>Deafault is '-', you can use your own, e.g. '|'.</small>
+            default: '-'
         dropdown:
             type: toggle
             label: Dropdown in Navigation

--- a/oxygen.yaml
+++ b/oxygen.yaml
@@ -5,6 +5,8 @@ enabled: true
 index: false
 # SEO: Add the global sitename to every page's title attribute
 sitetitle: false
+# SEO: Optional separator between page name and website name
+sitetitleseparator: '-'
 # if main navigation should display submenus in a dropdown on desktop
 dropdown: true
 # if jquery should be included, only necessary for some other plugins

--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -2,7 +2,7 @@
 <html lang="{{ grav.language.getActive ?: grav.config.site.default_lang }}">
 <head>
 {% block head %}
-	<title>{% if page.title %}{{ page.title|raw }}{% endif %}{% if config.theme.sitetitle %} - {{ site.title|raw }}{% endif %}</title>
+	<title>{% if page.title %}{{ page.title|raw }}{% endif %}{% if page.title and site.title and config.theme.sitetitle %} {{ config.theme.sitetitleseparator|raw }} {% endif %}{% if site.title and config.theme.sitetitle %}{{ site.title|raw }}{% endif %}</title>
 	<meta http-equiv="content-type" content="text/html; charset=utf-8">
 
 	{% include 'partials/metadata.html.twig' %}


### PR DESCRIPTION
Additionally, I added a separator field to blueprints.yaml (new since PR #21). I noticed that you renamed sublabel to description, so check for any other changes.